### PR TITLE
fixed py3 incompatibility

### DIFF
--- a/pymessenger2/utils.py
+++ b/pymessenger2/utils.py
@@ -20,8 +20,12 @@ def validate_hub_signature(app_secret, request_payload, hub_signature_header):
         pass
     else:
         digest_module = getattr(hashlib, hash_method)
-        hmac_object = hmac.new(
-            str(app_secret), unicode(request_payload), digest_module)
+        if six.PY2:
+            hmac_object = hmac.new(
+                str(app_secret), unicode(request_payload), digest_module)
+        else:
+            hmac_object = hmac.new(
+                bytearray(app_secret, 'utf8'), str(request_payload).encode('utf8'), digest_module)
         generated_hash = hmac_object.hexdigest()
         if hub_signature == generated_hash:
             return True


### PR DESCRIPTION
There was a small issue in `validate_hub_signature` (use of `unicode`) that throws an exception when the code is run using py3 