### PR TITLE
messenger-profile-api and handover-protocol APIs, code refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ ENV/
 # Rope project settings
 .ropeproject
 
+pymessenger2/README.rst

--- a/README.rst
+++ b/README.rst
@@ -294,11 +294,13 @@ class MyDialogFlowWebhook(generic.View):
             if dialogflow_action == "SAY HELLO":
                 chatbot = Bot(<YOUR_PAGE_ACCESS_TOKEN>,
                               raise_exception=True)
-                facebook_payload = chatbot.send_text_message(recipient_id=recipient_id,
+                bot_response_payload = chatbot.send_text_message(recipient_id=recipient_id,
                                                              message="Hi guy, I'm here!!!",
                                                              do_send=False)
                 response_data['payload'].update({
-                    "facebook": facebook_payload
+                    "facebook": [
+                        bot_response_payload['message']
+                    ]
                 })
         return response_data
 

--- a/README.rst
+++ b/README.rst
@@ -221,10 +221,10 @@ Output:
 Code: 
 
 
-.. code:: json
+.. code:: python
 
-   {'data': [{
-      'persistent_menu': [{
+   {"data": [{
+      "persistent_menu": [{
           "locale":"default",
           "composer_input_disabled": False,
           "call_to_actions":[
@@ -260,14 +260,14 @@ Code:
             }
           ]
         }],
-        'get_started': {'payload': 'Ciao'}, 
-        'greeting': [
-            {'locale': 'default', 'text': 'Hello!'}, 
-            {'locale': 'en_US', 'text': 'Hi'}, 
-            {'locale': 'it_IT', 'text': 'Ciao'}
+        "get_started": {"payload": "Ciao"}, 
+        "greeting": [
+            {"locale": "default", "text": "Hello!"}, 
+            {"locale": "en_US", "text": "Hi"}, 
+            {"locale": "it_IT", "text": "Ciao"}
         ], 
-        'whitelisted_domains': ["https://www.mywebsite.it",
-                                 "https://katesapp.ngrok.io"]
+        "whitelisted_domains": ["https://www.mywebsite.it",
+                                "https://katesapp.ngrok.io"]
     }]}
 
 Integration with DialogFlow:
@@ -310,11 +310,12 @@ You can see a simple Webhook implementation written in Django
                 recipient_id = request_data.get('originalDetectIntentRequest',{}).get('payload',{}).get('data',{}).get('sender',{}).get('id',None)
                 dialogflow_action = query_result.get('action', "")
                 if dialogflow_action == "SAY HELLO":
-                    chatbot = Bot(<YOUR_PAGE_ACCESS_TOKEN>,
-                                  raise_exception=True)
-                    bot_response_payload = chatbot.send_text_message(recipient_id=recipient_id,
-                                                                 message="Hi guy, I'm here!!!",
-                                                                 do_send=False)
+                    bot = Bot(<YOUR_PAGE_ACCESS_TOKEN>,
+                              raise_exception=True)
+                    bot_response_payload = chatbot.send_text_message(
+                        recipient_id=recipient_id,
+                         message="Hi guy, I'm here!!!",
+                         do_send=False)
                     response_data['payload'].update({
                         "facebook": [
                             bot_response_payload['message']

--- a/README.rst
+++ b/README.rst
@@ -199,8 +199,9 @@ ChatBot Configuration:
 Output:
 
 .. figure:: https://user-images.githubusercontent.com/2088831/41346006-895817ee-6f05-11e8-9048-f9a06df3f727.png
-   figure:: https://user-images.githubusercontent.com/2088831/41345991-8111431c-6f05-11e8-9d09-40df3a2a60be.png
-   :alt: Bot Configuration
+   :alt: Persistent Menu
+.. figure:: https://user-images.githubusercontent.com/2088831/41345991-8111431c-6f05-11e8-9d09-40df3a2a60be.png
+   :alt: Persistent Menu
 
    {'data': [{'persistent_menu': [{
           "locale":"default",

--- a/README.rst
+++ b/README.rst
@@ -49,9 +49,8 @@ Configurations:
 -  ``get_configuration()``
 -  ``clear_configuration(**payload)``
 
-Handover Protocol: 
-
-<https://developers.facebook.com/docs/messenger-platform/handover-protocol>
+Handover Protocol ( `see Facebook Docs <https://developers.facebook.com/docs/messenger-platform/handover-protocol>`_ )
+:
 
 - ``pass_thread_control(recipient_id, target_app_id, help_message)``
 - ``take_thread_control(recipient_id, message)``
@@ -205,12 +204,27 @@ ChatBot Configuration:
                                       
 Output:
 
-.. figure:: https://user-images.githubusercontent.com/2088831/41346006-895817ee-6f05-11e8-9048-f9a06df3f727.png
-   :alt: Persistent Menu
-.. figure:: https://user-images.githubusercontent.com/2088831/41345991-8111431c-6f05-11e8-9d09-40df3a2a60be.png
-   :alt: Persistent Menu
 
-   {'data': [{'persistent_menu': [{
+
+.. figure:: https://user-images.githubusercontent.com/2088831/41345991-8111431c-6f05-11e8-9d09-40df3a2a60be.png
+   :alt: Persistent Menu (Level 1)
+   
+   Persistent Menu (Level 1)
+
+ 
+.. figure:: https://user-images.githubusercontent.com/2088831/41346006-895817ee-6f05-11e8-9048-f9a06df3f727.png
+   :alt: Persistent Menu (Level 2)
+
+   Persistent Menu (Level 1)
+
+
+Code: 
+
+
+.. code:: json
+
+   {'data': [{
+      'persistent_menu': [{
           "locale":"default",
           "composer_input_disabled": False,
           "call_to_actions":[
@@ -253,62 +267,65 @@ Output:
             {'locale': 'it_IT', 'text': 'Ciao'}
         ], 
         'whitelisted_domains': ["https://www.mywebsite.it",
-                                 "https://katesapp.ngrok.io"]}]}
+                                 "https://katesapp.ngrok.io"]
+    }]}
 
 Integration with DialogFlow:
 '''''''''''''''''''''''''''''''''''
 If you want to use DialogFlow for your bot and customize Facebook return messages, you can use our Bot.
 
+You can see a simple Webhook implementation written in Django
+
 .. code:: python
 
-from pymessenger2.bot import Bot
+    from pymessenger2.bot import Bot
+    
+    ...
 
-
-class MyDialogFlowWebhook(generic.View):
+    class MyDialogFlowWebhook(generic.View):
   
-    def is_facebook_request(self, request_data):
-        return request_data.get('originalDetectIntentRequest',{}).get('source','') == 'facebook'
+        def is_facebook_request(self, request_data):
+            return request_data.get('originalDetectIntentRequest',{}).get('source','') == 'facebook'
 
-    def post(self, request, *args, **kwargs):
-        request_data = json.loads(request.body)
-        logger.debug("DialogFlow Webhook - Handling POST event\n"
-                     "data: {0}".format(data))
-        
-        ...  
-        
-        query_result=request_data.get('queryResult',{})
-        response_data = {
-            'fulfillmentText':query_result.get('fulfillmentText'),
-            'fulfillmentMessages':query_result.get('fulfillmentMessages'),
-            'payload':query_result.get('originalDetectIntentRequest',{}).get('payload',{}),
-            'outputContexts':query_result.get('outputContexts'),
-            'source':"dialogflow-webhook",
+        def post(self, request, *args, **kwargs):
+            request_data = json.loads(request.body)
+            logger.debug("DialogFlow Webhook - Handling POST event\n"
+                         "data: {0}".format(data))
             
-        }
-        
-        ...
+            ...  
+            
+            query_result=request_data.get('queryResult',{})
+            response_data = {
+                'fulfillmentText':query_result.get('fulfillmentText'),
+                'fulfillmentMessages':query_result.get('fulfillmentMessages'),
+                'payload':query_result.get('originalDetectIntentRequest',{}).get('payload',{}),
+                'outputContexts':query_result.get('outputContexts'),
+                'source':"dialogflow-webhook",
+                
+            }
+            
+            ...
 
-        if self.is_facebook_request(request_data):
-            recipient_id = request_data.get('originalDetectIntentRequest',{}).get('payload',{}).get('data',{}).get('sender',{}).get('id',None)
-            dialogflow_action = query_result.get('action', "")
-            if dialogflow_action == "SAY HELLO":
-                chatbot = Bot(<YOUR_PAGE_ACCESS_TOKEN>,
-                              raise_exception=True)
-                bot_response_payload = chatbot.send_text_message(recipient_id=recipient_id,
-                                                             message="Hi guy, I'm here!!!",
-                                                             do_send=False)
-                response_data['payload'].update({
-                    "facebook": [
-                        bot_response_payload['message']
-                    ]
-                })
-        return response_data
+            if self.is_facebook_request(request_data):
+                recipient_id = request_data.get('originalDetectIntentRequest',{}).get('payload',{}).get('data',{}).get('sender',{}).get('id',None)
+                dialogflow_action = query_result.get('action', "")
+                if dialogflow_action == "SAY HELLO":
+                    chatbot = Bot(<YOUR_PAGE_ACCESS_TOKEN>,
+                                  raise_exception=True)
+                    bot_response_payload = chatbot.send_text_message(recipient_id=recipient_id,
+                                                                 message="Hi guy, I'm here!!!",
+                                                                 do_send=False)
+                    response_data['payload'].update({
+                        "facebook": [
+                            bot_response_payload['message']
+                        ]
+                    })
+            return response_data
 
 
 
 Todo
 ~~~~
-'''''''''''''''''''''''''''''''''''
 -  Structured Messages
 -  Use Facepy?
 -  Receipt Messages

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,8 @@ About
 
 This wrapper has the following functions:
 
+Send Message:
+
 -  ``send_text_message(recipient_id, message)``
 -  ``send_message(recipient_id, message)``
 -  ``send_generic_message(recipient_id, elements)``
@@ -29,7 +31,22 @@ This wrapper has the following functions:
 -  ``send_file_url(recipient_id, file_url)``
 -  ``send_action(recipient_id, action)``
 -  ``send_raw(payload)``
+
+Profile Data:
+
 -  ``get_user_info(recipient_id)``
+
+Configurations:
+
+-  ``set_get_started(payload)``
+-  ``set_greeting(payload)``
+-  ``set_home_url(payload)``
+-  ``set_persistent_menu(payload)``
+-  ``set_target_audience(payload)``
+-  ``set_whitelisted_domains(payload)``
+-  ``add_domains_to_whitelist(payload)``
+-  ``send_configuration(payload)``
+-  ``clear_configuration(**payload)``
 
 You can see the code/documentation for there in
 `bot.py <pymessenger/bot.py>`__.

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Configurations:
 -  ``set_whitelisted_domains(payload)``
 -  ``add_domains_to_whitelist(payload)``
 -  ``send_configuration(payload)``
+-  ``get_configuration()``
 -  ``clear_configuration(**payload)``
 
 You can see the code/documentation for there in
@@ -131,10 +132,128 @@ Sending an image/video/file using an URL:
     image_url = "http://url/to/image.png"
     bot.send_image_url(recipient_id, image_url)
 
+
+ChatBot Configuration:
+'''''''''''''''''''''''''''''''''''
+
+    `Messenger Profile API <https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/>`__
+    allows you to manage congigurations like Persistent Menu, Whitelisted Domain, ecc.
+
+.. code:: python
+
+    from pymessenger2.bot import Bot
+    bot = Bot(<access_token>)
+    bot.set_get_started({"payload":"Hello Friend"})
+    bot.set_whitelisted_domains(["https://www.mywebsite.it",
+                                 "https://katesapp.ngrok.io"])
+    bot.set_greeting([
+          {
+            "locale":"default",
+            "text":"Hello!"
+          }, {
+            "locale":"en_US",
+            "text":"Hi"
+          }, {
+            "locale":"it_IT",
+            "text":"Ciao"
+          }
+    ])
+    bot.set_persistent_menu([{
+          "locale":"default",
+          "composer_input_disabled": False,
+          "call_to_actions":[
+            {
+              "title":"🍽 Recipes",
+              "type":"nested",
+              "call_to_actions":[
+                {
+                  "title":"🐟 Fish Recipes",
+                  "type":"postback",
+                  "payload":"FISH-RECIPES"
+                },
+                {
+                  "title":"🍖 Meat Recipes",
+                  "type":"postback",
+                  "payload":"MEAT-RECIPES"
+                },
+                {
+                  "title":"🍱 Japanese Recipes",
+                  "type":"postback",
+                  "payload":"JAPAN-RECIPES"
+                },
+                {
+                  "title":"🍆 Vegan Recipes",
+                  "type":"postback",
+                  "payload":"VEGAN-RECIPES"
+                },
+              ]
+            },{
+              "title":"🔔 Notifications",
+              "type":"postback",
+              "payload":"NOTIFICATIONS"
+            }
+          ]
+        }])
+    bot.get_configuration()
+                                      
+Output:
+
+.. figure:: https://user-images.githubusercontent.com/2088831/41346006-895817ee-6f05-11e8-9048-f9a06df3f727.png
+   figure:: https://user-images.githubusercontent.com/2088831/41345991-8111431c-6f05-11e8-9d09-40df3a2a60be.png
+   :alt: Bot Configuration
+
+   {'data': [{'persistent_menu': [{
+          "locale":"default",
+          "composer_input_disabled": False,
+          "call_to_actions":[
+            {
+              "title":"🍽 Recipes",
+              "type":"nested",
+              "call_to_actions":[
+                {
+                  "title":"🐟 Fish Recipes",
+                  "type":"postback",
+                  "payload":"FISH-RECIPES"
+                },
+                {
+                  "title":"🍖 Meat Recipes",
+                  "type":"postback",
+                  "payload":"MEAT-RECIPES"
+                },
+                {
+                  "title":"🍱 Japanese Recipes",
+                  "type":"postback",
+                  "payload":"JAPAN-RECIPES"
+                },
+                {
+                  "title":"🍆 Vegan Recipes",
+                  "type":"postback",
+                  "payload":"VEGAN-RECIPES"
+                },
+              ]
+            },{
+              "title":"🔔 Notifications",
+              "type":"postback",
+              "payload":"NOTIFICATIONS"
+            }
+          ]
+        }],
+        'get_started': {'payload': 'Ciao'}, 
+        'greeting': [
+            {'locale': 'default', 'text': 'Hello!'}, 
+            {'locale': 'en_US', 'text': 'Hi'}, 
+            {'locale': 'it_IT', 'text': 'Ciao'}
+        ], 
+        'whitelisted_domains': ["https://www.mywebsite.it",
+                                 "https://katesapp.ngrok.io"]}]}
+
+
 Todo
 ~~~~
 
 -  Structured Messages
+-  Handover Protocol <https://developers.facebook.com/docs/messenger-platform/handover-protocol>
+-  Use Facepy?
 -  Receipt Messages
 -  Airlines
 -  Tests!

--- a/pymessenger2/bot.py
+++ b/pymessenger2/bot.py
@@ -341,7 +341,7 @@ class Bot(object):
             Response from API as <dict>
         """
         return self.send_message(recipient_id, {
-                'text': message,
+                'text': str(message),
                 'quick_replies': buttons
                 }, notification_type, do_send=do_send)
     

--- a/pymessenger2/bot.py
+++ b/pymessenger2/bot.py
@@ -603,7 +603,7 @@ class Bot(object):
         :param recipient_id: PSID of Faceboook user
         :param target_app_id: Facebook APP ID
         :param help_message: String to pass to secondary receiver app
-        :return:
+        :return: json response
 
         """
         payload = {
@@ -612,9 +612,7 @@ class Bot(object):
             "metadata": help_message,
         }
         """
-        https://developers.facebook.com/docs/messenger-platform/reference/handover-protocol/pass-thread-control
-
-        @TODO Myabe Use facepy.graph_api.GraphAPI for exceptions handler and other shortcuts,
+        @TODO Maybe Use facepy.graph_api.GraphAPI for exceptions handler and other shortcuts,
               and to have an always update service.. if so `auth_args` will be unuseful
         """
         request_endpoint = '{0}/me/pass_thread_control'.format(self.graph_url)
@@ -656,11 +654,11 @@ class Bot(object):
 
     def take_thread_control(self, recipient_id, message=""):
         """
-        See  https://developers.facebook.com/docs/messenger-platform/reference/handover-protocol/pass-thread-control
+        See  https://developers.facebook.com/docs/messenger-platform/reference/handover-protocol/take-thread-control
 
         :param recipient_id: PSID of Faceboook user
         :param message: String to pass to secondary receiver app
-        :return: 
+        :return:  json response
 
         """
         payload = {
@@ -668,8 +666,6 @@ class Bot(object):
             "metadata": message,
         }
         """
-        https://developers.facebook.com/docs/messenger-platform/reference/handover-protocol/pass-thread-control
-
         @TODO Myabe Use facepy.graph_api.GraphAPI for exceptions handler and other shortcuts,
               and to have an always update service.. if so `auth_args` will be unuseful
         """

--- a/pymessenger2/bot.py
+++ b/pymessenger2/bot.py
@@ -132,8 +132,10 @@ class Bot(object):
         """
         request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
         if self.log_request:
-            print("request_endpoint : {0}".format(request_endpoint))
-            print("params : {0}".format(payload))
+            print("request to {0}: \n headers :{1}\n data: {2} "
+                  "".format(request_endpoint,
+                            self.auth_args,
+                            request_data))
         response = requests.post(
             request_endpoint,
             params=self.auth_args,
@@ -161,11 +163,13 @@ class Bot(object):
         })
         request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
         if self.log_request:
-            print("request_endpoint : {0}".format(request_endpoint))
-            print("params : {0}".format(params))
+            print("request to {0}: \n headers :{1}\n data: {2} "
+                  "".format(request_endpoint,
+                            self.auth_args,
+                            request_data))
         response = requests.get(
             request_endpoint,
-            params=self.auth_args,
+            params=params,
             #json=payload
         )
         result = response.json()
@@ -558,8 +562,9 @@ class Bot(object):
         #=======================================================================
         request_data = json.dumps(payload, cls=AttrsEncoder)
         if self.log_request:
-            print("request data to {0}: {1} "
+            print("request to {0}: \n headers :{1}\n data: {2} "
                   "".format(request_endpoint,
+                            self.auth_args,
                             request_data))
         response = requests.post(
             request_endpoint,
@@ -624,8 +629,9 @@ class Bot(object):
         #=======================================================================
         request_data = json.dumps(payload, cls=AttrsEncoder)
         if self.log_request:
-            print("request data to {0}: {1} "
+            print("request to {0}: \n headers :{1}\n data: {2} "
                   "".format(request_endpoint,
+                            self.auth_args,
                             request_data))
         response = requests.post(
             request_endpoint,
@@ -678,8 +684,9 @@ class Bot(object):
         #=======================================================================
         request_data = json.dumps(payload, cls=AttrsEncoder)
         if self.log_request:
-            print("request data to {0}: {1} "
+            print("request to {0}: \n headers :{1}\n data: {2} "
                   "".format(request_endpoint,
+                            self.auth_args,
                             request_data))
         response = requests.post(
             request_endpoint,

--- a/pymessenger2/bot.py
+++ b/pymessenger2/bot.py
@@ -1,5 +1,6 @@
 import os
 from enum import Enum
+import logging
 
 import six
 import json
@@ -10,6 +11,7 @@ from pymessenger2 import utils
 from pymessenger2.exceptions import OAuthError, FacebookError 
 from pymessenger2.utils import AttrsEncoder
 
+logger = logging.getLogger("pymessenger")
 
 DEFAULT_API_VERSION = 2.6
 
@@ -129,12 +131,18 @@ class Bot(object):
         https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api
         """
         request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
+        logger.debug("request_endpoint : {0}".format(request_endpoint))
+        logger.debug("params : {0}".format(payload))
         response = requests.post(
             request_endpoint,
             params=self.auth_args,
             json=payload
         )
         result = response.json()
+        error = result.get('error',{})
+        if error:
+            logger.error("{0}".format(error.get("message",'Facebook Error')))
+        logger.debug("result : {0}".format(result))
         return result
     
     def get_configuration(self, fields=[]):
@@ -150,8 +158,8 @@ class Bot(object):
             'fields':",".join(list(fields))
         })
         request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
-        print("request_endpoint : {0}".format(request_endpoint))
-        print("params : {0}".format(params))
+        logger.debug("request_endpoint : {0}".format(request_endpoint))
+        logger.debug("params : {0}".format(params))
         response = requests.get(
             request_endpoint,
             params=self.auth_args,

--- a/pymessenger2/bot.py
+++ b/pymessenger2/bot.py
@@ -41,6 +41,7 @@ class Bot(object):
             self.api_version)
         self.access_token = access_token
         self.verification_token = verification_token
+        self.raise_exception=raise_exception
 
     @property
     def auth_args(self):

--- a/pymessenger2/bot.py
+++ b/pymessenger2/bot.py
@@ -131,8 +131,9 @@ class Bot(object):
         https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api
         """
         request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
-        logger.debug("request_endpoint : {0}".format(request_endpoint))
-        logger.debug("params : {0}".format(payload))
+        if self.log_request:
+            print("request_endpoint : {0}".format(request_endpoint))
+            print("params : {0}".format(payload))
         response = requests.post(
             request_endpoint,
             params=self.auth_args,
@@ -141,8 +142,9 @@ class Bot(object):
         result = response.json()
         error = result.get('error',{})
         if error:
-            logger.error("{0}".format(error.get("message",'Facebook Error')))
-        logger.debug("result : {0}".format(result))
+            print("Error! : {0}".format(error.get("message",'Facebook Error')))
+        if self.log_response:
+            print("result : {0}".format(result))
         return result
     
     def get_configuration(self, fields=[]):
@@ -158,8 +160,9 @@ class Bot(object):
             'fields':",".join(list(fields))
         })
         request_endpoint = '{0}/me/messenger_profile'.format(self.graph_url)
-        logger.debug("request_endpoint : {0}".format(request_endpoint))
-        logger.debug("params : {0}".format(params))
+        if self.log_request:
+            print("request_endpoint : {0}".format(request_endpoint))
+            print("params : {0}".format(params))
         response = requests.get(
             request_endpoint,
             params=self.auth_args,

--- a/pymessenger2/bot.py
+++ b/pymessenger2/bot.py
@@ -595,7 +595,7 @@ class Bot(object):
     ###  HANDOVER PROTOCOL
     ##########################
     def pass_thread_control(self, recipient_id,
-                            target_app_id=263902037430900,  # Page inbox
+                            target_app_id="",  # Page inbox
                             help_message="Pass to Secondary Receiver"):
         """
         See  https://developers.facebook.com/docs/messenger-platform/reference/handover-protocol/pass-thread-control

--- a/pymessenger2/exceptions.py
+++ b/pymessenger2/exceptions.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+
+#===============================================================================
+# Taken from https://github.com/jgorset/facepy/blob/master/facepy/exceptions.py
+#===============================================================================
+class FacebookError(Exception):
+    def __init__(self, message=None, code=None, error_data=None, error_subcode=None,
+                 is_transient=None, error_user_title=None, error_user_msg=None,
+                 fbtrace_id=None):
+        self.message = message
+        self.code = code
+        self.error_data = error_data
+        self.error_subcode = error_subcode
+        self.is_transient = is_transient
+        self.error_user_title = error_user_title
+        self.error_user_msg = error_user_msg
+        self.fbtrace_id = fbtrace_id
+
+        if self.code:
+            message = '[%s] %s' % (self.code, self.message)
+
+        super(FacebookError, self).__init__(message)
+        
+class OAuthError(FacebookError):
+    pass


### PR DESCRIPTION
Hi guys, as I told you some months ago, i had to deploy some chatbots.
I have used your Bot and customized it for my needs
I have created two chatbots, one of them used by a webhook fullfillment for a DialogFlow Application associated to a Facebook App

So i did a lot of changes

I have implemented:
 - API for Configurations for Facebook bot (see [Facebook Docs](https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/))
 - possiblity to return data (see `do_send` variable) instead of calling Chatbot directly, useful for DialogFlow Bots
 - API for Handover Protocol  (see [Facebook Docs](https://developers.facebook.com/docs/messenger-platform/handover-protocol)) if you want to "pause" automatic responses e pass the control to an other Bot

Unfortunately i did no tests, but I would be very happy if my changes were available to everyone, so as to improve the code in both style and functionality.

Thank you in advance

Have a nice weekend